### PR TITLE
Ab headcount sql review

### DIFF
--- a/inst/sql/headcount/headcount_census.sql
+++ b/inst/sql/headcount/headcount_census.sql
@@ -3,7 +3,7 @@ Census/3rd Week headcount
 */
 
 SELECT a.term_desc,
-       COUNT(a.student_id) AS current_headcount
+       COUNT(a.student_id) AS census_headcount
 FROM export.student_term_level_version a
          LEFT JOIN export.term b
                    ON a.term_id = b.term_id

--- a/inst/sql/headcount/headcount_census.sql
+++ b/inst/sql/headcount/headcount_census.sql
@@ -1,15 +1,15 @@
 /*
-Census/3rd Week headcount from Edify
+Census/3rd Week headcount
 */
 
-   SELECT a.term_desc,
-          COUNT(a.sis_system_id) AS current_headcount
-     FROM export.student_term_level_version a
-LEFT JOIN export.term b
-       ON a.term_id = b.term_id
-    WHERE a.is_enrolled IS TRUE
-      AND a.is_primary_level IS TRUE
-      AND a.version_desc = 'Census'
-      AND DATE_PART('year', NOW()) - b.academic_year_code :: INT <= 5 -- Current term plus last 5 Years.
- GROUP BY a.term_desc
- ORDER BY a.term_desc;
+SELECT a.term_desc,
+       COUNT(a.student_id) AS current_headcount
+FROM export.student_term_level_version a
+         LEFT JOIN export.term b
+                   ON a.term_id = b.term_id
+WHERE a.is_enrolled IS TRUE
+  AND a.is_primary_level IS TRUE
+  AND a.version_desc = 'Census'
+  AND DATE_PART('year', NOW()) - b.academic_year_code :: INT <= 5 -- Current year plus last 5 years
+GROUP BY a.term_desc
+ORDER BY a.term_desc;

--- a/inst/sql/headcount/headcount_census_groups.sql
+++ b/inst/sql/headcount/headcount_census_groups.sql
@@ -1,7 +1,7 @@
-/*Census headcount groups
+/*
+Census headcount groups
 provides unit record data, to get headcount you must group and summarize
 Definitions for each of these groups can be found in the groups vignette in utDataStoR
-
  */
 SELECT a.term_id,
        a.term_desc,

--- a/inst/sql/headcount/headcount_census_groups.sql
+++ b/inst/sql/headcount/headcount_census_groups.sql
@@ -1,9 +1,14 @@
+/*Census headcount groups
+provides unit record data, to get headcount you must group and summarize
+
+ */
 SELECT a.term_id,
        a.term_desc,
        c.season,
        a.student_id,
-       a.level_id,
-       a.level_desc,
+       a.level_id AS student_level_id,
+       a.level_desc AS student_level_desc,
+       a.student_type_code,
        a.student_type_desc,
        b.ipeds_race_ethnicity,
        b.gender_code,
@@ -11,28 +16,47 @@ SELECT a.term_id,
            WHEN b.gender_code = 'F' THEN 'Female'
            WHEN b.gender_code = 'M' THEN 'Male'
            ELSE b.gender_code
-           END                    AS gender_desc,
-       a.full_time_part_time_code AS credit_load,
+           END                        AS gender_desc,
+       a.full_time_part_time_code     AS course_load_code,
+       CASE
+           WHEN a.full_time_part_time_code = 'F' THEN 'Full-time'
+           WHEN a.full_time_part_time_code = 'P' THEN 'Part-time'
+           ELSE a.full_time_part_time_code
+           END AS course_load_desc,
        b.is_first_generation,
        a.is_pell_eligible,
        a.is_pell_awarded,
+       a.is_subsidized_loan_awarded,
        b.is_veteran,
-       a.is_athlete               AS is_athlete_current_term,
+       a.is_athlete                   AS is_athlete_term,
+       b.us_citizenship_code,
        b.us_citizenship_desc,
        b.is_international,
        a.is_degree_seeking,
        a.is_subsidized_loan_awarded,
-       b.is_underrepresented_minority,
+       b.is_underrepresented_minority AS is_minority,
        b.first_admit_county_desc,
        b.first_admit_state_desc,
        b.first_admit_country_desc,
+       a.residency_code AS tuition_residency_code,
+       a.residency_code_desc AS tuition_residency_desc,
+       a.residency_in_state_code AS state_residency_code,
+       a.residency_in_state_desc AS state_residency_desc,
        a.residency_in_state_desc,
        CASE
            WHEN b.primary_visa_type_code = 'F1' AND b.us_citizenship_code = '2' THEN 'international'
            WHEN a.residency_in_state_code = 'I' THEN 'in_state'
            WHEN a.residency_in_state_code = 'O' THEN 'out_of_state'
+           WHEN a.residency_in_state_code IS NULL AND a.residency_code = 'R' THEN 'in_state'
+           WHEN a.residency_in_state_code IS NULL AND a.residency_code = 'A' THEN 'in_state'
+           WHEN a.residency_in_state_code IS NULL AND a.residency_code = 'B' THEN 'in_state'
+           WHEN a.residency_in_state_code IS NULL AND a.residency_code = 'C' THEN 'in_state'
+           WHEN a.residency_in_state_code IS NULL AND a.residency_code = 'M' THEN 'in_state'
+           WHEN a.residency_in_state_code IS NULL AND a.residency_code = 'N' THEN 'out_of_state'
+           WHEN a.residency_in_state_code IS NULL AND a.residency_code = 'G' THEN 'out_of_state'
+           WHEN a.residency_in_state_code IS NULL AND a.residency_code = 'H' THEN 'out_of_state'
            ELSE a.residency_code
-           END                    AS residency,
+           END                        AS global_residency,
        CASE
            WHEN EXTRACT(YEAR from AGE(current_date, b.birth_date)) < 18 THEN 'less than 18'
            WHEN EXTRACT(YEAR from AGE(current_date, b.birth_date)) BETWEEN 18 and 24 THEN '18 to 24'
@@ -41,24 +65,43 @@ SELECT a.term_id,
            WHEN EXTRACT(YEAR from AGE(current_date, b.birth_date)) BETWEEN 45 and 59 THEN '45 to 59'
            WHEN EXTRACT(YEAR from AGE(current_date, b.birth_date)) > 59 THEN '60 plus'
            ELSE 'error'
-           END                    AS age_band,
+           END                        AS age_band,
        CASE
            WHEN a.overall_cumulative_gpa < 2.0 THEN '0_to_1.999'
            WHEN a.overall_cumulative_gpa BETWEEN 2.0 AND 2.499 THEN '2_to_2.499'
            WHEN a.overall_cumulative_gpa BETWEEN 2.5 AND 2.999 THEN '2.5_to_2.999'
            WHEN a.overall_cumulative_gpa BETWEEN 3.0 AND 4 THEN '3_to_4'
            ELSE 'new'
-           END                    AS gpa_band,
+           END                        AS overall_cumulative_gpa_band,
+       CASE
+           WHEN a.institutional_term_gpa < 2.0 THEN '0_to_1.999'
+           WHEN a.institutional_term_gpa BETWEEN 2.0 AND 2.499 THEN '2_to_2.499'
+           WHEN a.institutional_term_gpa BETWEEN 2.5 AND 2.999 THEN '2.5_to_2.999'
+           WHEN a.institutional_term_gpa BETWEEN 3.0 AND 4 THEN '3_to_4'
+           ELSE 'new'
+        END AS institutional_term_gpa_band,
+       CASE
+           WHEN a.student_type_code = 'H' THEN TRUE
+           ELSE FALSE
+           END AS is_high_school,
        CASE
            WHEN a.student_type_code = 'P' THEN TRUE
            ELSE FALSE
-           END                    AS is_non_matriculated,
+           END                        AS is_non_matriculated,
        d.college_abbrv,
        d.college_id,
-       d.major_desc,
-       a.primary_degree_id,
        d.department_desc,
-       a.primary_level_class_desc,
+       a.primary_program_id           AS program_id,
+       a.primary_program_desc         AS program_desc,
+       a.primary_concentration_id     AS concentration_id,
+       a.primary_concentration_desc   AS concentration_desc,
+       a.primary_degree_id            AS degree_id,
+       a.primary_degree_desc          AS degree_desc,
+       d.major_id,
+       d.major_desc,
+       a.primary_level_class_id.      AS class_level_id,
+       a.primary_level_class_desc     AS class_level_desc,
+       a.is_online_program_student,
        a.is_distance_ed_some,
        a.is_distance_ed_none,
        a.is_distance_ed_all,
@@ -71,65 +114,18 @@ SELECT a.term_id,
            WHEN b.is_hispanic_latino_ethnicity = 'TRUE' THEN 'BIPOC'
            WHEN b.is_multi_racial = 'TRUE' THEN 'BIPOC'
            ELSE 'non-BIPOC'
-           END                    AS BIPOC_student
+           END                        AS BIPOC_student
 
 FROM export.student_term_level_version a
          LEFT JOIN export.student_version b
                    ON a.version_snapshot_id = b.version_snapshot_id
-                       AND a.student_id = b.student_id
+                   AND a.student_id = b.student_id
          LEFT JOIN export.term c
                    ON a.term_id = c.term_id
          LEFT JOIN export.academic_programs d
                    ON a.primary_program_id = d.program_id
-WHERE a.is_enrolled = TRUE
-  AND a.is_primary_level = TRUE
-  AND DATE_PART('year', NOW()) - c.academic_year_code :: INT <= 3
+WHERE a.is_enrolled IS TRUE
+  AND a.is_primary_level IS TRUE
+  AND DATE_PART('year', NOW()) - b.academic_year_code :: INT <= 5 -- Current year plus last 5 years
   AND a.version_desc = 'Census'
-GROUP BY a.term_id, a.term_desc, c.season, a.student_id, a.level_id, a.level_desc, a.student_type_desc,
-         b.ipeds_race_ethnicity,
-         b.gender_code,
-         CASE
-             WHEN b.gender_code = 'F' THEN 'Female'
-             WHEN b.gender_code = 'M' THEN 'Male'
-             ELSE b.gender_code
-             END, a.full_time_part_time_code, b.is_first_generation, a.is_pell_eligible, a.is_pell_awarded,
-         b.is_veteran, a.is_athlete, b.us_citizenship_desc, b.is_international, a.is_degree_seeking,
-         a.is_subsidized_loan_awarded, b.is_underrepresented_minority, b.first_admit_county_desc,
-         b.first_admit_state_desc, b.first_admit_country_desc, a.residency_in_state_desc,
-         CASE
-             WHEN b.primary_visa_type_code = 'F1' AND b.us_citizenship_code = '2' THEN 'international'
-             WHEN a.residency_in_state_code = 'I' THEN 'in_state'
-             WHEN a.residency_in_state_code = 'O' THEN 'out_of_state'
-             ELSE a.residency_code
-             END,
-         CASE
-             WHEN EXTRACT(YEAR from AGE(current_date, b.birth_date)) < 18 THEN 'less than 18'
-             WHEN EXTRACT(YEAR from AGE(current_date, b.birth_date)) BETWEEN 18 and 24 THEN '18 to 24'
-             WHEN EXTRACT(YEAR from AGE(current_date, b.birth_date)) BETWEEN 25 and 34 THEN '25 to 34'
-             WHEN EXTRACT(YEAR from AGE(current_date, b.birth_date)) BETWEEN 35 and 44 THEN '35 to 44'
-             WHEN EXTRACT(YEAR from AGE(current_date, b.birth_date)) BETWEEN 45 and 59 THEN '45 to 59'
-             WHEN EXTRACT(YEAR from AGE(current_date, b.birth_date)) > 59 THEN '60 plus'
-             ELSE 'error'
-             END,
-         CASE
-             WHEN a.overall_cumulative_gpa < 2.0 THEN '0_to_1.999'
-             WHEN a.overall_cumulative_gpa BETWEEN 2.0 AND 2.499 THEN '2_to_2.499'
-             WHEN a.overall_cumulative_gpa BETWEEN 2.5 AND 2.999 THEN '2.5_to_2.999'
-             WHEN a.overall_cumulative_gpa BETWEEN 3.0 AND 4 THEN '3_to_4'
-             ELSE 'new'
-             END,
-         CASE
-             WHEN a.student_type_code = 'P' THEN TRUE
-             ELSE FALSE
-             END, d.college_abbrv, d.college_id, d.major_desc, a.primary_degree_id, d.department_desc,
-         a.primary_level_class_desc, a.is_distance_ed_some, a.is_distance_ed_none, a.is_distance_ed_all,
-         act_composite_score,
-         CASE
-             WHEN b.is_american_indian_alaskan = 'TRUE' THEN 'BIPOC'
-             WHEN b.is_asian = 'TRUE' THEN 'BIPOC'
-             WHEN b.is_black = 'TRUE' THEN 'BIPOC'
-             WHEN b.is_hawaiian_pacific_islander = 'TRUE' THEN 'BIPOC'
-             WHEN b.is_hispanic_latino_ethnicity = 'TRUE' THEN 'BIPOC'
-             WHEN b.is_multi_racial = 'TRUE' THEN 'BIPOC'
-             ELSE 'non-BIPOC'
-             END;
+ORDER BY a.student_id, a.term_id

--- a/inst/sql/headcount/headcount_census_groups.sql
+++ b/inst/sql/headcount/headcount_census_groups.sql
@@ -1,5 +1,6 @@
 /*Census headcount groups
 provides unit record data, to get headcount you must group and summarize
+for information about definitions for each of these groups, please see the groups vignette in utDataStoR
 
  */
 SELECT a.term_id,
@@ -33,7 +34,6 @@ SELECT a.term_id,
        b.us_citizenship_desc,
        b.is_international,
        a.is_degree_seeking,
-       a.is_subsidized_loan_awarded,
        b.is_underrepresented_minority AS is_minority,
        b.first_admit_county_desc,
        b.first_admit_state_desc,
@@ -42,7 +42,6 @@ SELECT a.term_id,
        a.residency_code_desc AS tuition_residency_desc,
        a.residency_in_state_code AS state_residency_code,
        a.residency_in_state_desc AS state_residency_desc,
-       a.residency_in_state_desc,
        CASE
            WHEN b.primary_visa_type_code = 'F1' AND b.us_citizenship_code = '2' THEN 'international'
            WHEN a.residency_in_state_code = 'I' THEN 'in_state'
@@ -79,7 +78,7 @@ SELECT a.term_id,
            WHEN a.institutional_term_gpa BETWEEN 2.5 AND 2.999 THEN '2.5_to_2.999'
            WHEN a.institutional_term_gpa BETWEEN 3.0 AND 4 THEN '3_to_4'
            ELSE 'new'
-        END AS institutional_term_gpa_band,
+           END                       AS institutional_term_gpa_band,
        CASE
            WHEN a.student_type_code = 'H' THEN TRUE
            ELSE FALSE

--- a/inst/sql/headcount/headcount_census_groups.sql
+++ b/inst/sql/headcount/headcount_census_groups.sql
@@ -1,6 +1,6 @@
 /*Census headcount groups
 provides unit record data, to get headcount you must group and summarize
-for information about definitions for each of these groups, please see the groups vignette in utDataStoR
+Definitions for each of these groups can be found in the groups vignette in utDataStoR
 
  */
 SELECT a.term_id,

--- a/inst/sql/headcount/headcount_current.sql
+++ b/inst/sql/headcount/headcount_current.sql
@@ -1,15 +1,15 @@
 /*
-Current headcount from Edify.
+Current headcount
 */
 
-   SELECT a.term_desc,
-          COUNT(a.sis_system_id) AS current_headcount
-     FROM export.student_term_level_version a
-LEFT JOIN export.term b
-       ON a.term_id = b.term_id
-    WHERE a.is_enrolled IS TRUE
-      AND a.is_primary_level IS TRUE
-      AND a.version_desc = 'Current'
-      AND DATE_PART('year', NOW()) - b.academic_year_code :: INT <= 5 -- Last 5 Years
- GROUP BY a.term_desc
- ORDER BY a.term_desc;
+SELECT a.term_desc,
+       COUNT(a.student_id) AS current_headcount
+FROM export.student_term_level_version a
+         LEFT JOIN export.term b
+                   ON a.term_id = b.term_id
+WHERE a.is_enrolled IS TRUE
+  AND a.is_primary_level IS TRUE
+  AND a.version_desc = 'Current'
+  AND DATE_PART('year', NOW()) - b.academic_year_code :: INT <= 5 -- Current year plus last 5 years
+GROUP BY a.term_desc
+ORDER BY a.term_desc;

--- a/inst/sql/headcount/headcount_end_of_term.sql
+++ b/inst/sql/headcount/headcount_end_of_term.sql
@@ -1,16 +1,15 @@
 /*
-End of Term headcount from Edify
+End of Term headcount
 */
 
 SELECT a.term_desc,
-          COUNT(a.sis_system_id) AS current_headcount
-     FROM export.student_term_level_version a
-LEFT JOIN export.term b
-       ON a.term_id = b.term_id
-    WHERE a.is_enrolled IS TRUE
-      AND a.is_primary_level IS TRUE
-      AND a.version_desc = 'End of Term'
-      AND DATE_PART('year', NOW()) - b.academic_year_code :: INT <= 5 -- Last 5 Years
-      AND b.season IN ('Fall', 'Spring') -- Fall and Spring only
- GROUP BY a.term_desc
- ORDER BY a.term_desc;
+       COUNT(a.student_id) AS current_headcount
+FROM export.student_term_level_version a
+         LEFT JOIN export.term b
+                   ON a.term_id = b.term_id
+WHERE a.is_enrolled IS TRUE
+  AND a.is_primary_level IS TRUE
+  AND a.version_desc = 'End of Term'
+  AND DATE_PART('year', NOW()) - b.academic_year_code :: INT <= 5 -- Current year plus last 5 years
+GROUP BY a.term_desc
+ORDER BY a.term_desc;

--- a/inst/sql/headcount/headcount_end_of_term.sql
+++ b/inst/sql/headcount/headcount_end_of_term.sql
@@ -3,7 +3,7 @@ End of Term headcount
 */
 
 SELECT a.term_desc,
-       COUNT(a.student_id) AS current_headcount
+       COUNT(a.student_id) AS eot_headcount
 FROM export.student_term_level_version a
          LEFT JOIN export.term b
                    ON a.term_id = b.term_id

--- a/inst/sql/headcount/headcount_ipeds_12_month.sql
+++ b/inst/sql/headcount/headcount_ipeds_12_month.sql
@@ -1,5 +1,5 @@
-/*IPEDS 12 Month headcount
-
+/*
+IPEDS 12 Month headcount
  */
 
 SELECT b.academic_year_code,

--- a/inst/sql/headcount/headcount_ipeds_12_month.sql
+++ b/inst/sql/headcount/headcount_ipeds_12_month.sql
@@ -2,14 +2,14 @@
 
  */
 
-  SELECT b.academic_year_code,
-         COUNT(DISTINCT a.sis_system_id)
-     FROM export.student_term_level_version a
-LEFT JOIN export.term b
-       ON a.term_id = b.term_id
-    WHERE a.is_enrolled = TRUE
-      AND a.is_primary_level = TRUE
-      AND a.version_desc = 'Census'
-      AND b.academic_year_code = '2022'
-      AND b.season != 'Summer'
- GROUP BY academic_year_code;
+SELECT b.academic_year_code,
+       COUNT(DISTINCT a.student_id) --unduplicated students over the course of an academic year
+FROM export.student_term_level_version a
+         LEFT JOIN export.term b
+                   ON a.term_id = b.term_id
+WHERE a.is_enrolled = TRUE
+  AND a.is_primary_level = TRUE
+  AND a.version_desc = 'Census'
+  AND DATE_PART('year', NOW()) - b.academic_year_code :: INT = 1 -- Last academic year
+  AND b.season != 'Summer'                                       -- remove summer as per ipeds requirement
+GROUP BY academic_year_code;

--- a/inst/sql/headcount/headcount_point_in_time.sql
+++ b/inst/sql/headcount/headcount_point_in_time.sql
@@ -8,7 +8,7 @@ SELECT term_id,
        days_to_class_start,
        COUNT(DISTINCT student_id) AS headcount
 FROM export.daily_enrollment
-WHERE term_id = '202340'
-AND is_enrolled IS TRUE
+WHERE is_current_term IS TRUE -- Only pulling current term
+  AND is_enrolled IS TRUE
 GROUP BY term_id, date, days_to_class_start
 ORDER BY date DESC;

--- a/inst/sql/headcount/headcount_point_in_time.sql
+++ b/inst/sql/headcount/headcount_point_in_time.sql
@@ -1,5 +1,5 @@
-/* daily headcount
-
+/*
+daily headcount
 */
 
 SELECT term_id,


### PR DESCRIPTION
- headcount_census changes - changed the description (removed "from Edify"); changed a.sis_system_id to a.student_id for consistency.
- headcount_current changes - changed the description (removed "from Edify"); changed a.sis_system_id to a.student_id for consistency.
- headcount_end_of_term changes - changed the description (removed "from Edify"); changed a.sis_system_id to a.student_id for consistency; removed line 14 that included only Fall and Spring and excluded summer for consistency.
- headcount_ipeds_12_month changes - changed a.sis_system_id to a.student_id for consistency; removed the hard coding of academic year and changed to current academic year minus 1 making it for the previous year as IPEDS requires; added additional documentation.
- headcount_point_in_time - removed the hard coding of the term and changed to current term assuming that is what most people would want.
- headcount_census_groups - added a header with additional description; renamed level_id code and desc; renamed credit_load to course_load to match groups vignette; added is_subsidized_loan_awarded; renamed is_athlete_term to match groups vignette; recoded minority and renamed underrepresented_minority; added, fixed and renamed residency codes; renamed gpa_band to overall_cumulative_gpa_band for clarity; renamed all the program codes and pieces to match the groups vignette; renamed class_level id and code; changed = TRUE to IS TRUE to be consitent with other headcount sql; changed time frame to current year plus 5 years of data to be consistent with other headcount sql; removed the unneeded group by statement.