### PR TITLE
Feature sql retention

### DIFF
--- a/inst/sql/retention/cohort_retention.sql
+++ b/inst/sql/retention/cohort_retention.sql
@@ -1,5 +1,7 @@
 /*
  Cohort Retention
+ Uses student term cohort table as the base table. Includes students in the first-time freshman cohort in the fall semester.
+ Includes data to calculate Cohort Retention over time.
  */
     SELECT a.student_id,
            a.cohort_start_term_id,
@@ -41,13 +43,13 @@ LEFT JOIN export.term b
 LEFT JOIN export.student_term_level_version c
        ON c.student_id = a.student_id
       AND c.term_id = a.cohort_start_term_id
-      AND c.is_enrolled
-      AND c.is_primary_level
-      AND c.is_census_version
+      AND c.is_enrolled IS TRUE
+      AND c.is_primary_level IS TRUE
+      AND c.is_census_version IS TRUE
 LEFT JOIN export.academic_programs d
        ON d.program_id = c.primary_program_id
 LEFT JOIN export.student e
        ON e.student_id = a.student_id
     WHERE b.season = 'Fall'
       AND a.cohort_desc = 'First-Time Freshman'
-      AND DATE_PART('year', NOW()) - b.academic_year_code :: INT <= 8
+      AND DATE_PART('year', NOW()) - b.academic_year_code :: INT <= 8 -- Current year plus last 8 years so that there is 5 years of data for fourth fall return rate

--- a/inst/sql/retention/cohort_retention.sql
+++ b/inst/sql/retention/cohort_retention.sql
@@ -1,6 +1,6 @@
 /*
  Cohort Retention
- Uses student term cohort table as the base table. Includes students in the first-time freshman cohort in the fall semester.
+ Uses student term cohort table as the base table. Comprises of students in the first-time freshman cohort in the fall semester.
  Includes data to calculate Cohort Retention over time.
  */
     SELECT a.student_id,
@@ -21,6 +21,7 @@
            -- Fourth fall return rate
            a.is_returned_fall_4,
            a.is_degree_completer_3,
+           --
            c.primary_major_desc,
            c.primary_degree_id,
            c.primary_degree_desc,

--- a/inst/sql/retention/cohort_retention.sql
+++ b/inst/sql/retention/cohort_retention.sql
@@ -3,6 +3,12 @@
  */
     SELECT a.student_id,
            a.cohort_start_term_id,
+           a.cohort_desc,
+           a.full_time_part_time_code,
+           a.cohort_degree_level_desc,
+           b.term_desc,
+           b.season,
+           SUBSTRING(b.term_id, 1, 4) AS year,
            a.is_exclusion,
            -- Second fall return rate
            a.is_returned_next_fall,
@@ -18,9 +24,12 @@
            c.primary_degree_desc,
            d.college_abbrv,
            d.college_desc,
-           e.first_name,
-           e.last_name,
            e.gender_code,
+           CASE
+           WHEN e.gender_code = 'M' THEN 'Male'
+           WHEN e.gender_code = 'F' THEN 'Female'
+           ELSE 'Unspecified'
+           END AS gender_desc,
            e.ipeds_race_ethnicity,
            e.is_veteran,
            e.is_international,
@@ -41,6 +50,4 @@ LEFT JOIN export.student e
        ON e.student_id = a.student_id
     WHERE b.season = 'Fall'
       AND a.cohort_desc = 'First-Time Freshman'
-      AND substr(a.cohort_start_term_id, 1, 4)::int >= (SELECT substr(term_id, 1, 4)::int - 5
-                                     FROM export.term
-                                     WHERE is_current_term)
+      AND DATE_PART('year', NOW()) - b.academic_year_code :: INT <= 8

--- a/inst/sql/retention/term_to_term_retention.sql
+++ b/inst/sql/retention/term_to_term_retention.sql
@@ -3,16 +3,23 @@
  */
    SELECT a.student_id,
           a.term_id,
+          b.term_desc,
+          b.season,
+          SUBSTRING(a.term_id, 1, 4) AS year,
           a.is_returned_next_spring,
           a.is_returned_next_fall,
+          a.is_degree_seeking,
           c.primary_major_desc,
           c.primary_degree_id,
           c.primary_degree_desc,
           d.college_abbrv,
           d.college_desc,
-          e.first_name,
-          e.last_name,
           e.gender_code,
+          CASE
+           WHEN e.gender_code = 'M' THEN 'Male'
+           WHEN e.gender_code = 'F' THEN 'Female'
+           ELSE 'Unspecified'
+           END AS gender_desc,
           e.ipeds_race_ethnicity,
           e.is_veteran,
           e.is_international,
@@ -37,7 +44,8 @@ LEFT JOIN export.student e
 LEFT JOIN export.student_term_cohort f
        ON f.student_id = a.student_id
       AND f.cohort_desc IN ('First-Time Freshman', 'Transfer')
-    WHERE b.season = 'Fall'
+    WHERE a.is_enrolled_census
+      AND b.season = 'Fall'
       AND substr(a.term_id, 1, 4)::int >= (SELECT substr(term_id, 1, 4)::int - 5
                                      FROM export.term
                                      WHERE is_current_term)

--- a/inst/sql/retention/term_to_term_retention.sql
+++ b/inst/sql/retention/term_to_term_retention.sql
@@ -1,5 +1,7 @@
 /*
  Term to term retention
+ Uses student term outcome as the base table. Includes students enrolled as of census.
+ Includes data to calculate Term to Term Retention (both Come Back rate and Return rate).
  */
    SELECT a.student_id,
           a.term_id,
@@ -8,12 +10,21 @@
           SUBSTRING(a.term_id, 1, 4) AS year,
           a.is_returned_next_spring,
           a.is_returned_next_fall,
-          a.is_degree_seeking,
+          a.is_graduated
+            OR a.is_degree_completer_certificate
+            OR a.is_degree_completer_associates
+            OR a.is_degree_completer_bachelors
+            OR a.is_degree_completer_masters
+            OR a.is_degree_completer_doctorate AS is_credential_completer,
           c.primary_major_desc,
           c.primary_degree_id,
           c.primary_degree_desc,
           d.college_abbrv,
           d.college_desc,
+          a.is_degree_seeking,
+          c.level_desc,
+          c.student_type_desc,
+          c.full_time_part_time_code,
           e.gender_code,
           CASE
            WHEN e.gender_code = 'M' THEN 'Male'
@@ -27,16 +38,16 @@
           e.is_first_generation,
           COALESCE(f.is_exclusion, FALSE) AS is_exclusion,
           COALESCE(f.cohort_start_term_id, 'None') AS cohort_start_term_id,
-          COALESCE(f.cohort_desc, 'None') AS cohort_type
+          COALESCE(f.cohort_desc, 'None') AS cohort_desc
      FROM export.student_term_outcome a
 LEFT JOIN export.term b
        ON b.term_id = a.term_id
 LEFT JOIN export.student_term_level_version c
        ON c.student_id = a.student_id
       AND c.term_id = a.term_id
-      AND c.is_enrolled
-      AND c.is_primary_level
-      AND c.is_census_version
+      AND c.is_enrolled IS TRUE
+      AND c.is_primary_level IS TRUE
+      AND c.is_census_version IS TRUE
 LEFT JOIN export.academic_programs d
        ON d.program_id = c.primary_program_id
 LEFT JOIN export.student e
@@ -44,8 +55,6 @@ LEFT JOIN export.student e
 LEFT JOIN export.student_term_cohort f
        ON f.student_id = a.student_id
       AND f.cohort_desc IN ('First-Time Freshman', 'Transfer')
-    WHERE a.is_enrolled_census
+    WHERE a.is_enrolled_census IS TRUE
       AND b.season = 'Fall'
-      AND substr(a.term_id, 1, 4)::int >= (SELECT substr(term_id, 1, 4)::int - 5
-                                     FROM export.term
-                                     WHERE is_current_term)
+      AND DATE_PART('year', NOW()) - b.academic_year_code :: INT <= 5 -- Current year plus last 5 years


### PR DESCRIPTION
This feature branch makes changes to the retention sql. The goal is to provide the basic data needed to create retention metrics, and to have this sql be consistent with the rest of the sql in utDataStoR.

cohort retention 
- added documentation about the sql
- added term description, season, and year
- added cohort specific information
- removed student identifying information
- added gender description
- changed the way the dates were pulled and extended the years the query ran to allow for retention data over greater amounts of time
- made the sql consistent with other sql in utDataStoR

term-to-term retention
- added documentation about the sql
- added term description, season, and year
- added graduation and completer credentials so the return rate can be calculated
- removed student identifying information
- added degree seeking, student level, student type and full-time part-time indicators which are useful in retention calculations
- added gender description
- created consistency in the cohort_desc naming
- changed the way the dates were pulled
- added where is_enrolled_census
- made the sql consistent with other sql in utDataStoR